### PR TITLE
Fix Screen import in QML example

### DIFF
--- a/hello-world/Main.qml
+++ b/hello-world/Main.qml
@@ -2,6 +2,7 @@
 // @see: [The official Qt tutorial](https://doc.qt.io/qt-6/qml-tutorial1.html)
 
 import QtQuick
+import QtQuick.Window
 
 Window {
 	id: mainWindow // id *attribute* is used to reference this object in this QML file


### PR DESCRIPTION
## Summary
- import `QtQuick.Window` in `Main.qml` so the `Screen` attached property works at runtime

## Testing
- `qmlscene hello-world/Main.qml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_685ce4c6b09083218936e7502c610cd1